### PR TITLE
[FIX][IMP] sale/account: improve CFDI autofill and invoice status display

### DIFF
--- a/cdfi_invoice/.gitignore
+++ b/cdfi_invoice/.gitignore
@@ -1,0 +1,53 @@
+# Archivos de caché de Python
+_pycache_/
+*.pyc
+*.pyo
+*.pyd
+
+# Configuración de editores de código
+.vscode/
+.idea/
+*.sublime-workspace
+*.swp
+
+# Archivos de logs
+logs/
+*.log
+
+# Archivos de pruebas y datos temporales
+tests/
+*.coverage
+*.pytest_cache/
+
+# Archivos de compilación
+*.egg-info/
+*.dist-info/
+*.tox/
+build/
+dist/
+
+# Base de datos SQLite (si se usa para pruebas)
+*.db
+
+# Carpetas generadas por Odoo
+*.pot
+*.po~
+*.mo
+*.zip
+*.tar.gz
+*.bak
+*.tmp
+
+# Archivos de configuración de Odoo que pueden cambiar en cada entorno
+config/
+odoo.conf
+
+# Archivos específicos de Docker y Virtual Environments
+.env
+venv/
+.envrc
+.dockerignore
+
+# Archivos de dependencias locales
+node_modules/
+bower_components/

--- a/cdfi_invoice/models/sale.py
+++ b/cdfi_invoice/models/sale.py
@@ -1,85 +1,115 @@
 # -*- coding: utf-8 -*-
 
 from odoo import api, fields, models, _
-#import odoo.addons.decimal_precision as dp
-from  . import amount_to_text_es_MX
+
+# import odoo.addons.decimal_precision as dp
+from . import amount_to_text_es_MX
 import pytz
 import logging
+
 _logger = logging.getLogger(__name__)
 
+
 class SaleOrder(models.Model):
-    _inherit = 'sale.order'
+    _inherit = "sale.order"
 
-    forma_pago_id  =  fields.Many2one('catalogo.forma.pago', string='Forma de pago')
-    #num_cta_pago = fields.Char(string='Núm. Cta. Pago')
+    forma_pago_id = fields.Many2one("catalogo.forma.pago", string="Forma de pago")
+    # num_cta_pago = fields.Char(string='Núm. Cta. Pago')
     methodo_pago = fields.Selection(
-        selection=[('PUE', 'Pago en una sola exhibición'),
-                   ('PPD', 'Pago en parcialidades o diferido'),],
-        string='Método de pago',
+        selection=[
+            ("PUE", "Pago en una sola exhibición"),
+            ("PPD", "Pago en parcialidades o diferido"),
+        ],
+        string="Método de pago",
     )
-    uso_cfdi_id  =  fields.Many2one('catalogo.uso.cfdi', string='Uso CFDI (cliente)')
-    fecha_corregida = fields.Datetime(string='Fecha Cotizacion', compute='_get_fecha_corregida')
-    company_cfdi = fields.Boolean(related="company_id.company_cfdi",store=True)
+    uso_cfdi_id = fields.Many2one("catalogo.uso.cfdi", string="Uso CFDI (cliente)")
+    fecha_corregida = fields.Datetime(
+        string="Fecha Cotizacion", compute="_get_fecha_corregida"
+    )
+    company_cfdi = fields.Boolean(related="company_id.company_cfdi", store=True)
 
-    @api.onchange('partner_id')
+    @api.onchange("partner_id")
     def _get_uso_cfdi(self):
         if self.partner_id:
-            values = {
-                'uso_cfdi_id': self.partner_id.uso_cfdi_id.id
-                }
+            values = {"uso_cfdi_id": self.partner_id.uso_cfdi_id.id}
             self.update(values)
 
-    @api.onchange('payment_term_id')
+    @api.onchange("payment_term_id")
     def _get_metodo_pago(self):
         if self.payment_term_id:
-            if self.payment_term_id.methodo_pago == 'PPD':
+            if self.payment_term_id.methodo_pago == "PPD":
                 values = {
-                 'methodo_pago': self.payment_term_id.methodo_pago,
-                 'forma_pago_id': self.env['catalogo.forma.pago'].sudo().search([('code','=','99')])
-             }
+                    "methodo_pago": self.payment_term_id.methodo_pago,
+                    "forma_pago_id": self.env["catalogo.forma.pago"]
+                    .sudo()
+                    .search([("code", "=", "99")]),
+                }
             else:
                 values = {
-                 'methodo_pago': self.payment_term_id.methodo_pago,
-                 'forma_pago_id': False
-             }
-        else:
-            values = {
-                'methodo_pago': False,
-                'forma_pago_id': False
+                    "methodo_pago": self.payment_term_id.methodo_pago,
+                    "forma_pago_id": False,
                 }
+        else:
+            values = {"methodo_pago": False, "forma_pago_id": False}
         self.update(values)
 
-    @api.depends('amount_total', 'currency_id')
+    @api.depends("amount_total", "currency_id")
     def _get_amount_to_text(self):
         for record in self:
-            record.amount_to_text = amount_to_text_es_MX.get_amount_to_text(record, record.amount_total, 'es_cheque', record.currency_id.name)
-        
+            record.amount_to_text = amount_to_text_es_MX.get_amount_to_text(
+                record, record.amount_total, "es_cheque", record.currency_id.name
+            )
+
     @api.model
     def _get_amount_2_text(self, amount_total):
-        return amount_to_text_es_MX.get_amount_to_text(self, amount_total, 'es_cheque', self.currency_id.name)
-        
-    
+        return amount_to_text_es_MX.get_amount_to_text(
+            self, amount_total, "es_cheque", self.currency_id.name
+        )
+
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
-        invoice_vals.update({'forma_pago_id': self.forma_pago_id.id,
-                    'methodo_pago': self.methodo_pago,
-                    'uso_cfdi_id': self.uso_cfdi_id.id,
-                    'tipo_comprobante': 'I'
-                    })
+        invoice_vals.update(
+            {
+                "forma_pago_id": self.forma_pago_id.id,
+                "methodo_pago": self.methodo_pago,
+                "uso_cfdi_id": self.uso_cfdi_id.id,
+                "tipo_comprobante": "I",
+            }
+        )
         return invoice_vals
 
-    
     def _get_fecha_corregida(self):
         for sale in self:
-           if sale.date_order:
-              #corregir hora
-              timezone = sale._context.get('tz')
-              if not timezone:
-                  timezone = sale.env.user.partner_id.tz or 'America/Mexico_City'
-              #timezone = tools.ustr(timezone).encode('utf-8')
+            if sale.date_order:
+                # corregir hora
+                timezone = sale._context.get("tz")
+                if not timezone:
+                    timezone = sale.env.user.partner_id.tz or "America/Mexico_City"
+                # timezone = tools.ustr(timezone).encode('utf-8')
 
-              local = pytz.timezone(timezone)
-              naive_from = sale.date_order
-              local_dt_from = naive_from.replace(tzinfo=pytz.UTC).astimezone(local)
-              sale.fecha_corregida = local_dt_from.strftime ("%Y-%m-%d %H:%M:%S")
-              #_logger.info('fecha ... %s', sale.fecha_corregida)
+                local = pytz.timezone(timezone)
+                naive_from = sale.date_order
+                local_dt_from = naive_from.replace(tzinfo=pytz.UTC).astimezone(local)
+                sale.fecha_corregida = local_dt_from.strftime("%Y-%m-%d %H:%M:%S")
+                # _logger.info('fecha ... %s', sale.fecha_corregida)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        orders = super().create(vals_list)
+
+        for order in orders:
+
+            if order.partner_id and not order.uso_cfdi_id:
+                order.uso_cfdi_id = order.partner_id.uso_cfdi_id.id
+
+            if order.payment_term_id:
+                order.methodo_pago = order.payment_term_id.methodo_pago
+
+                if order.payment_term_id.methodo_pago == "PPD":
+                    order.forma_pago_id = (
+                        self.env["catalogo.forma.pago"]
+                        .sudo()
+                        .search([("code", "=", "99")], limit=1)
+                    )
+
+        return orders

--- a/cdfi_invoice/views/account_invoice_view.xml
+++ b/cdfi_invoice/views/account_invoice_view.xml
@@ -1,102 +1,167 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-	
-    <record id="view_invoice_inherit_tree" model="ir.ui.view">
+
+    <record id="view_invoice_inherit_tree"
+        model="ir.ui.view">
         <field name="name">account.move.inherit.tree</field>
         <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_invoice_tree" />
-        <field name="arch" type="xml">
-            <field name="status_in_payment" position="before">
-                <field name="company_cfdi" invisible="1"/> <!-- invisible -->
-                <field name="estado_factura" string="Estado CFDI" invisible="company_cfdi == False"/>
+        <field name="inherit_id"
+            ref="account.view_invoice_tree" />
+        <field name="arch"
+            type="xml">
+            <field name="status_in_payment"
+                position="before">
+                <field name="company_cfdi"
+                    invisible="1"/>
+                <!-- invisible -->
+                <field name="estado_factura"
+                    string="Estado CFDI"
+                    widget="badge"
+                    decoration-danger="estado_factura == 'factura_no_generada'"
+                    decoration-success="estado_factura == 'factura_correcta'"
+                    decoration-warning="estado_factura == 'solicitud_cancelar'"
+                    decoration-muted="estado_factura == 'factura_cancelada'"
+                    decoration-primary="estado_factura == 'solicitud_rechazada'"
+                    invisible="company_cfdi == False"/>
             </field>
         </field>
     </record>
 
-    <record id="view_invoice_inherit_form" model="ir.ui.view">
-            <field name="name">account.move.inherit.form</field>
-            <field name="model">account.move</field>
-            <field name="inherit_id" ref="account.view_move_form" />
-            <field name="arch" type="xml">
-                <xpath expr="//notebook" position="inside">
-                    <field name="company_cfdi" invisible="1"/> <!-- invisible -->
-                    <page name="info_cdfi" string="CFDI" invisible="company_cfdi == False and move_type in ('entry', 'out_receipt', 'in_receipt')">
-                            <group cols="4">
-                                <group string="Detalles de Pago">
-                                    <field name="forma_pago_id" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="methodo_pago" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="uso_cfdi_id" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="exportacion" readonly="estado_factura != 'factura_no_generada'"/>
-                                </group>
-                                <group  string="Detalles de Factura">
-                                    <field name="tipo_comprobante" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="folio_fiscal"/>
-                                    <field name="confirmacion" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="estado_factura"/>
-                                    <field name="fecha_factura" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="proceso_timbrado"/>
-                                </group>
-                                <group  string="CFDI Relacionados">
-                                    <field name="tipo_relacion" readonly="estado_factura != 'factura_no_generada'"/>
-                                    <field name="uuid_relacionado" readonly="estado_factura != 'factura_no_generada'"/>
-                                </group>
-                                <group  string="Complementos" name="complementos" invisible="move_type != 'out_invoice'">
-                                    <field name="factura_global" readonly="estado_factura != 'factura_no_generada'"/>
-                                </group>
-                            </group>
-                    </page>
-                    <page name="info_global" string="Factura global" invisible="factura_global == False">
-                        <group cols="4">
-                            <group>
-                                <field name="fg_periodicidad" readonly="estado_factura != 'factura_no_generada'"/>
-                                <field name="fg_meses" readonly="estado_factura != 'factura_no_generada'"/>
-                                <field name="fg_ano" readonly="estado_factura != 'factura_no_generada'"/>
-                            </group>
+    <record id="view_invoice_inherit_form"
+        model="ir.ui.view">
+        <field name="name">account.move.inherit.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id"
+            ref="account.view_move_form" />
+        <field name="arch"
+            type="xml">
+            <xpath expr="//notebook"
+                position="inside">
+                <field name="company_cfdi"
+                    invisible="1"/>
+                <!-- invisible -->
+                <page name="info_cdfi"
+                    string="CFDI"
+                    invisible="company_cfdi == False and move_type in ('entry', 'out_receipt', 'in_receipt')">
+                    <group cols="4">
+                        <group string="Detalles de Pago">
+                            <field name="forma_pago_id"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="methodo_pago"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="uso_cfdi_id"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="exportacion"
+                                readonly="estado_factura != 'factura_no_generada'"/>
                         </group>
-                    </page>
-                </xpath>
-                <field name="ref" position="after">
-                    <field name="factura_cfdi" invisible="1"/> <!-- invisible -->
-                </field>
-                <button name="action_invoice_sent" position="before">
-                    <button name="action_invoice_sent" type="object" string="Enviar por correo-e" 
-                                     invisible="state not in 'cancel' or company_cfdi == False" groups="base.group_user"/>
-                </button>
-                <button name="button_draft" position="before">
-                    <button name="action_cfdi_generate" type="object" string="Generar CFDI"
-                            invisible= "state in ['draft','cancel'] or estado_factura in ['factura_correcta','factura_cancelada','solicitud_rechazada'] or
-                                   move_type not in ['out_invoice', 'out_refund'] or company_cfdi == False" class="oe_highlight" groups="base.group_user"/>
-                    <button name="%(cdfi_invoice.reason_cancelation_sat_wizard)d"
-                            type="action" 
-                            string="Cancelar CFDI" 
-                            invisible="factura_cfdi == False or estado_factura in ['solicitud_cancelar', 'factura_cancelada', 'solicitud_rechazada'] or
-                                    company_cfdi == False"  class="oe_highlight" groups="base.group_user"/>
-                    <button name="action_cfdi_rechazada"
-                            type="object" 
-                            string="Cambiar estado CFDI a factura correcta" 
-                            invisible="factura_cfdi == False or estado_factura not in ['solicitud_cancelar', 'solicitud_rechazada'] or
-                                   company_cfdi == False" class="oe_highlight" groups="base.group_user"
-                            confirm="La factura va pasar a estado correcto y puede intentar cancelar nuevamente."/>
-                </button>
+                        <group string="Detalles de Factura">
+                            <field name="tipo_comprobante"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="folio_fiscal"/>
+                            <field name="confirmacion"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="estado_factura"/>
+                            <field name="fecha_factura"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="proceso_timbrado"/>
+                        </group>
+                        <group string="CFDI Relacionados">
+                            <field name="tipo_relacion"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="uuid_relacionado"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                        </group>
+                        <group string="Complementos"
+                            name="complementos"
+                            invisible="move_type != 'out_invoice'">
+                            <field name="factura_global"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                        </group>
+                    </group>
+                </page>
+                <page name="info_global"
+                    string="Factura global"
+                    invisible="factura_global == False">
+                    <group cols="4">
+                        <group>
+                            <field name="fg_periodicidad"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="fg_meses"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                            <field name="fg_ano"
+                                readonly="estado_factura != 'factura_no_generada'"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+            <field name="ref"
+                position="after">
+                <field name="factura_cfdi"
+                    invisible="1"/>
+                <!-- invisible -->
             </field>
-        </record>
+            <button name="action_invoice_sent"
+                position="before">
+                <button name="action_invoice_sent"
+                    type="object"
+                    string="Enviar por correo-e"
+                    invisible="state not in 'cancel' or company_cfdi == False"
+                    groups="base.group_user"/>
+            </button>
+            <button name="button_draft"
+                position="before">
+                <button name="action_cfdi_generate"
+                    type="object"
+                    string="Generar CFDI"
+                    invisible= "state in ['draft','cancel'] or estado_factura in ['factura_correcta','factura_cancelada','solicitud_rechazada'] or
+                                   move_type not in ['out_invoice', 'out_refund'] or company_cfdi == False"
+                    class="oe_highlight"
+                    groups="base.group_user"/>
+                <button name="%(cdfi_invoice.reason_cancelation_sat_wizard)d"
+                    type="action"
+                    string="Cancelar CFDI"
+                    invisible="factura_cfdi == False or estado_factura in ['solicitud_cancelar', 'factura_cancelada', 'solicitud_rechazada'] or
+                                    company_cfdi == False"
+                    class="oe_highlight"
+                    groups="base.group_user"/>
+                <button name="action_cfdi_rechazada"
+                    type="object"
+                    string="Cambiar estado CFDI a factura correcta"
+                    invisible="factura_cfdi == False or estado_factura not in ['solicitud_cancelar', 'solicitud_rechazada'] or
+                                   company_cfdi == False"
+                    class="oe_highlight"
+                    groups="base.group_user"
+                    confirm="La factura va pasar a estado correcto y puede intentar cancelar nuevamente."/>
+            </button>
+        </field>
+    </record>
 
-    <record id="model_action_liberar_cfdi" model="ir.actions.server">
+    <record id="model_action_liberar_cfdi"
+        model="ir.actions.server">
         <field name="name">Desbloquear CFDI</field>
-        <field name="model_id" ref="account.model_account_move"/>
-        <field name="binding_model_id" ref="account.model_account_move"/>
+        <field name="model_id"
+            ref="account.model_account_move"/>
+        <field name="binding_model_id"
+            ref="account.model_account_move"/>
         <field name="state">code</field>
         <field name="code">action = records.liberar_cfdi()</field>
     </record>
 
-    <record id="mymodule_message_wizard_form" model="ir.ui.view">
+    <record id="mymodule_message_wizard_form"
+        model="ir.ui.view">
         <field name="name">mymodule.message.wizard.form</field>
         <field name="model">mymodule.message.wizard</field>
-        <field name="arch" type="xml">
+        <field name="arch"
+            type="xml">
             <form>
-                <field name="message" readonly="True"/>
+                <field name="message"
+                    readonly="True"/>
                 <footer>
-                    <button name="action_close" string="Ok" type="object" default_focus="1" class="oe_highlight"/>
+                    <button name="action_close"
+                        string="Ok"
+                        type="object"
+                        default_focus="1"
+                        class="oe_highlight"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
[FIX] sale: autofill CFDI data on website orders
Override create() in sale.order to populate CFDI fields for website purchases.
<img width="472" height="287" alt="image" src="https://github.com/user-attachments/assets/5e4948fb-4070-4061-bebb-6aa735da5f5a" />


[IMP] account: improve invoice status visibility
Add badge widget and decorations in view_invoice_inherit_tree for estado_factura.
<img width="682" height="177" alt="invoice list" src="https://github.com/user-attachments/assets/31355437-c95a-4468-8867-6408c923c9d2" />


[ADD] gitignore